### PR TITLE
fix LDAP_LIB for openldap 2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DEFS =
 LDAP_SRC = ../../../..
 LDAP_BUILD = ../../../..
 LDAP_INC = -I$(LDAP_BUILD)/include -I$(LDAP_SRC)/include -I$(LDAP_SRC)/servers/slapd
-LDAP_LIB = $(LDAP_BUILD)/libraries/libldap_r/libldap_r.la \
+LDAP_LIB = $(LDAP_BUILD)/libraries/libldap/libldap.la \
 	$(LDAP_BUILD)/libraries/liblber/liblber.la
 
 LIBTOOL = $(LDAP_BUILD)/libtool


### PR DESCRIPTION
change "libldap_r" to "libldap"